### PR TITLE
fix test detection in multi-root workspace

### DIFF
--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -27,7 +27,7 @@ export class ResolveHandler {
 
 				watcher.onDidCreate(uri => this.getOrCreateFile(root, uri));
 				watcher.onDidChange(uri => this.parseTestsInFile(uri));
-				watcher.onDidDelete(uri => root.children.delete(uri.toString()));
+				watcher.onDidDelete(uri => root.children.delete(workspace.asRelativePath(uri.fsPath, false)));
 
 				for (const file of await workspace.findFiles(pattern)) {
 					const testItem = this.getOrCreateFile(root, file);
@@ -60,8 +60,9 @@ export class ResolveHandler {
 	}
 
 	parseTestsInDocument = async (e: TextDocument) => {
-		if (workspace.name) {
-			const root = this.controller.items.get(workspace.name);
+		const workspaceFolder = workspace.getWorkspaceFolder(e.uri)
+		if (workspaceFolder) {
+			const root = this.controller.items.get(workspaceFolder.name);
 			if (root) {
 				const file = this.getOrCreateFile(root, e.uri);
 				if (file) {
@@ -72,8 +73,9 @@ export class ResolveHandler {
 	}
 
 	parseTestsInFile = async (uri: Uri) => {
-		if (workspace.name) {
-			const root = this.controller.items.get(workspace.name);
+		const workspaceFolder = workspace.getWorkspaceFolder(uri)
+		if (workspaceFolder) {
+			const root = this.controller.items.get(workspaceFolder.name);
 			if (root) {
 				const file = this.getOrCreateFile(root, uri);
 				if (file) {

--- a/tests/resolver.spec.ts
+++ b/tests/resolver.spec.ts
@@ -41,6 +41,15 @@ describe('resolver', () => {
 
     const testItem = mockDeep<vscode.TestItem>();
 
+    const workspaceFolder = mockDeep<vscode.WorkspaceFolder>({
+        uri: {
+            scheme: 'directory',
+            fsPath: 'path/to/starklings',
+        },
+        name: "starklings",
+        index: 1
+    });
+
     beforeEach(() => {
         jest.resetAllMocks();
     });
@@ -183,6 +192,7 @@ describe('resolver', () => {
 
         it('should call the parser if file is created', async () => {
             vscode.workspace.asRelativePath.mockReturnValue(testFile.uri!.fsPath);
+            vscode.workspace.getWorkspaceFolder.calledWith(testFile.uri).mockReturnValue(workspaceFolder);
             controller.items.get.mockReturnValue(root);
             root.children.get.mockReturnValue(testFile);
 
@@ -203,6 +213,7 @@ describe('resolver', () => {
 
         it('should call the parser if file is created', async () => {
             vscode.workspace.asRelativePath.mockReturnValue(testFile.uri!.fsPath);
+            vscode.workspace.getWorkspaceFolder.calledWith(testDocument.uri).mockReturnValue(workspaceFolder);
             controller.items.get.mockReturnValue(root);
             root.children.get.mockReturnValue(testFile);
             testDocument.getText.mockReturnValue('content');


### PR DESCRIPTION
In a multi-root workspace, when a test file is being added/modified/deleted, tests are not reflected in the side bar.
This PR aims at fixing this issue.