### PR TITLE
feat: activate extension for protostar projects only

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,6 +2,17 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest: current file",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "args": ["${fileBasenameNoExtension}", "--config", "jest.config.js"],
+      "console": "integratedTerminal",
+      "windows": {
+        "program": "${workspaceFolder}/node_modules/jest/bin/jest"
+      }
+    },
+    {
       "type": "extensionHost",
       "request": "launch",
       "name": "Protostar adapter",

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Test results will be displayed in the test output console.
 
 ![test view](img/test-result.gif)
 
+This extension detects Protostar projects using the `protostar.toml` file and/or test files like `*test*.cairo`.
+If the automatic activation does not work, it is possible to manually launch the extension using the 
+"Launch Protostar Test Explorer" command accessible from the vscode menu (`Ctrl-Shift-P`).
+
 ## 🫶 Contributing
 
 Contribution guidelines are specified in [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -15,6 +15,7 @@ export type FileSystemWatcher = vscode.FileSystemWatcher;
 export type TestRunProfile = vscode.TestRunProfile;
 export type Disposable = vscode.Disposable;
 export type TextDocumentChangeEvent = vscode.TextDocumentChangeEvent;
+export type Command = vscode.Command;
 
 export const RelativePattern = mockFn();
 export const TestMessage = mockFn();
@@ -46,5 +47,10 @@ export namespace tests {
 }
 
 export namespace window {
-  export const createOutputChannel = mockFn();
+    export const createOutputChannel = mockFn();
+    export const showInformationMessage = mockFn();
+}
+
+export namespace commands {
+    export const registerCommand = mockFn();
 }

--- a/__mocks__/vscode.ts
+++ b/__mocks__/vscode.ts
@@ -47,10 +47,10 @@ export namespace tests {
 }
 
 export namespace window {
-    export const createOutputChannel = mockFn();
-    export const showInformationMessage = mockFn();
+  export const createOutputChannel = mockFn();
+  export const showInformationMessage = mockFn();
 }
 
 export namespace commands {
-    export const registerCommand = mockFn();
+  export const registerCommand = mockFn();
 }

--- a/package.json
+++ b/package.json
@@ -56,7 +56,9 @@
     "vscode": "^1.59.0"
   },
   "activationEvents": [
-    "onStartupFinished"
+    "workspaceContains:**/protostar.toml",
+    "workspaceContains:**/*test*.cairo",
+    "onCommand:vscode-protostar-test-adapter.launchProtostarExtension"
   ],
   "contributes": {
     "configuration": {
@@ -74,6 +76,12 @@
           "scope": "resource"
         }
       }
-    }
+    },
+    "commands": [
+      {
+        "command": "vscode-protostar-test-adapter.launchProtostarExtension",
+        "title": "Launch Protostar Test Explorer"
+      }
+    ]
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,6 +4,14 @@ import { ResolveHandler } from './resolver';
 import { Parser } from './parser';
 
 export async function activate(context: vscode.ExtensionContext) {
+	const manualLaunchCommand = vscode.commands
+		.registerCommand("vscode-protostar-test-adapter.launchProtostarExtension", () => {
+			vscode.window.showInformationMessage('Protostar Test Explorer launched successfully!\n\
+				(Please use this command only if the extension was not automatically launched, \
+				i.e. you changed protostar default configuration)');
+		})	
+	context.subscriptions.push(manualLaunchCommand);
+
 	const controller = vscode.tests.createTestController('protostar-test-controller', 'Protostar Test Controller');
 	context.subscriptions.push(controller);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,12 +4,12 @@ import { ResolveHandler } from './resolver';
 import { Parser } from './parser';
 
 export async function activate(context: vscode.ExtensionContext) {
-	const manualLaunchCommand = vscode.commands
-		.registerCommand("vscode-protostar-test-adapter.launchProtostarExtension", () => {
-			vscode.window.showInformationMessage('Protostar Test Explorer launched successfully!\n\
+	const showCmdMsg = 
+		vscode.window.showInformationMessage('Protostar Test Explorer launched successfully!\n\
 				(Please use this command only if the extension was not automatically launched, \
 				i.e. you changed protostar default configuration)');
-		})	
+	
+	const manualLaunchCommand = vscode.commands.registerCommand("vscode-protostar-test-adapter.launchProtostarExtension", () => showCmdMsg);
 	context.subscriptions.push(manualLaunchCommand);
 
 	const controller = vscode.tests.createTestController('protostar-test-controller', 'Protostar Test Controller');

--- a/tests/main.spec.ts
+++ b/tests/main.spec.ts
@@ -57,10 +57,26 @@ describe('main', () => {
                 listener(changeEvent);
             });
 
+            const showCmdMsg = mockDeep<vscode.Command>();
+            vscode.window.showInformationMessage.calledWith(
+                'Protostar Test Explorer launched successfully!\n\
+				(Please use this command only if the extension was not automatically launched, \
+				i.e. you changed protostar default configuration)').mockReturnValue(showCmdMsg);
+
+            const manualLaunchCommand = mockDeep<vscode.Disposable>();
+            vscode.commands.registerCommand.calledWith(
+                "vscode-protostar-test-adapter.launchProtostarExtension", anyFunction())
+                .mockReturnValue(manualLaunchCommand)
+                .mockImplementation((command: string, callback: () => any) => {
+                   callback(); 
+                });
+
             const context = mockDeep<vscode.ExtensionContext>()
             await activate(context);
 
-            expect(context.subscriptions.push).toHaveBeenCalledWith(controller);
+            expect(context.subscriptions.push).toHaveBeenCalledTimes(2);
+
+            expect(context.subscriptions.push).toHaveBeenNthCalledWith(2, controller);
 
             expect(resolver.parseTestsInDocument).toHaveBeenCalledWith(changeEvent.document);
 


### PR DESCRIPTION
## User story

As a user I want to activate the extension for protostar projects only so that it does not show when no test can be found

## Details

Detects Protostar projects using the `protostar.toml` file and/or test files like `*test*.cairo`.
Search these files recursively (with the glob `**`) in the current workspace. 
For multiple projects it is better to open each root folders separately in a single workspace (as a multi-root workspace setup).

If the automatic activation does not work, it is possible to manually launch the extension using the 
"Launch Protostar Test Explorer" command accessible from the vscode menu (`Ctrl-Shift-P`).
